### PR TITLE
Pridana CSS trieda pre bunku obsahujúcu filter

### DIFF
--- a/Grido/Components/Filters/Filter.php
+++ b/Grido/Components/Filters/Filter.php
@@ -180,7 +180,7 @@ abstract class Filter extends \Grido\Base
     {
         if (!$this->wrapperPrototype) {
             $this->wrapperPrototype = \Nette\Utils\Html::el('th')
-                ->setClass([ 'grid-filter-' . $this->getName() ]);
+                ->setClass(array('grid-filter-' . $this->getName()));
         }
 
         return $this->wrapperPrototype;


### PR DESCRIPTION
Narazil som na problém, že som potreboval cez CSS zmenšiť šírku jedného stĺpca. Samotné dáta a header tabuľky sa dali zacieliť cez _grid-cell-*_, _grid-header-*_, ale CSS bunka s filtrom nie. Preto som pridal _grid-filter-*_ CSS triedu.
