### PR TITLE
DataSources\DibiFluent: getCount wrong limit

### DIFF
--- a/Grido/DataSources/DibiFluent.php
+++ b/Grido/DataSources/DibiFluent.php
@@ -99,7 +99,7 @@ class DibiFluent extends Base implements IDataSource
     public function getCount()
     {
         $fluent = clone $this->fluent;
-        return $fluent->removeClause('ORDER BY')->removeClause('SELECT')->select('COUNT(*)')->fetchSingle();
+        return $fluent->count();
     }
 
     /**


### PR DESCRIPTION
In the getCount() method there was 

$fluent->removeClause('ORDER BY')->removeClause('SELECT')->select('COUNT(*)')->fetchSingle(); 

which in my case returns wrong limit for paginator (i.e. 1 instead of 10). 
Im not sure if this "fix" is widely wanted, so, you decide ;-)
