### PR TITLE
Reset saved state

### DIFF
--- a/Grido/Grid.php
+++ b/Grido/Grid.php
@@ -553,7 +553,7 @@ class Grid extends \Nette\Application\UI\Control
     protected function loadRememberState(array &$params)
     {
         $session = $this->getRememberSession();
-        if ($this->presenter->signal) {
+        if ($this->presenter->isSignalReceiver($this)) {
             $session->remove();
         } elseif (!$params && $session->params) {
             $params = (array) $session->params;


### PR DESCRIPTION
Grid state should be reset only if the grid is signal receiver, because if you have signals in presenter, grid sorting will be always reset even if the signal is not for grid.
