### PR TITLE
simplified: propertyAccessor

### DIFF
--- a/Grido/Components/Actions/Href.php
+++ b/Grido/Components/Actions/Href.php
@@ -94,29 +94,17 @@ class Href extends Action
             return;
         }
 
-        $pk = $this->getPrimaryKey();
-        $hasPk = $this->grid->propertyAccessor->hasProperty($item, $pk);
-
-        if (!$this->customRender && !$hasPk) {
-            throw new \InvalidArgumentException("Primary key '$pk' not found.");
-        }
-
-        $href = NULL;
-        if ($this->customHref) {
-            $href = callback($this->customHref)->invokeArgs(array($item));
-        } elseif ($hasPk) {
-            $this->arguments[$pk] = $this->grid->propertyAccessor->getProperty($item, $pk);
-            $href = $this->presenter->link($this->getDestination(), $this->arguments);
-        }
-
         $text = $this->translate($this->label);
         $this->icon ? $text = ' ' . $text : $text;
-
+        $pk = $this->getPrimaryKey();
         $el = clone $this->getElementPrototype()
             ->setText($text);
 
-        if ($href) {
-            $el->href($href);
+        if ($this->customHref) {
+            $el->href(callback($this->customHref)->invokeArgs(array($item)));
+        } else {
+            $this->arguments[$pk] = $this->grid->propertyAccessor->getProperty($item, $pk);
+            $el->href($this->presenter->link($this->getDestination(), $this->arguments));
         }
 
         if ($this->confirm) {

--- a/Grido/Components/Columns/Column.php
+++ b/Grido/Components/Columns/Column.php
@@ -323,9 +323,6 @@ abstract class Column extends \Grido\Components\Base
     {
         $column = $this->getColumn();
         if (is_string($column)) {
-            if (!$this->grid->propertyAccessor->hasProperty($row, $column)) {
-                throw new \InvalidArgumentException("Column '$column' does not exist in datasource.");
-            }
             return $this->grid->propertyAccessor->getProperty($row, $column);
         } elseif (is_callable($column)) {
             return callback($column)->invokeArgs(array($row));

--- a/Grido/PropertyAccessors/ArrayObjectAccessor.php
+++ b/Grido/PropertyAccessors/ArrayObjectAccessor.php
@@ -23,34 +23,17 @@ class ArrayObjectAccessor implements IPropertyAccessor
     /**
      * @param mixed $object
      * @param string $name
-     * @return bool
-     */
-    public static function hasProperty($object, $name)
-    {
-        if (is_object($object) && $object instanceof \Nette\Database\Table\ActiveRow) {
-            //FUCKING \Nette\Database! https://github.com/nette/nette/pull/1100
-            return array_key_exists($name, $object->toArray());
-        } elseif (is_object($object) && $object instanceof \ArrayObject) {
-            return $object->offsetExists($name);
-        } elseif (is_object($object)) {
-            return property_exists($object, $name);
-        } elseif (is_array($object) || $object instanceof \ArrayAccess) {
-            return array_key_exists($name, $object);
-        } else {
-            throw new \InvalidArgumentException('Please implement your own property accessor.');
-        }
-    }
-
-    /**
-     * @param mixed $object
-     * @param string $name
      * @return mixed
      */
     public static function getProperty($object, $name)
     {
-        return isset($object->$name) || (is_object($object) && property_exists($object, $name))
-            ? $object->$name
-            : $object[$name];
+        if (is_object($object)) {
+            return $object->$name;
+        } else if (is_array($object) || $object instanceof \ArrayAccess) {
+            return $object[$name];
+        }
+
+        throw new \InvalidArgumentException('Please implement your own property accessor.');
     }
 
     /**
@@ -60,10 +43,12 @@ class ArrayObjectAccessor implements IPropertyAccessor
      */
     public static function setProperty($object, $name, $value)
     {
-        if (isset($object->$name) || (is_object($object) && property_exists($object, $name))) {
+        if (is_object($object)) {
             $object->$name = $value;
-        } else {
+        } else if (is_array($object) || $object instanceof \ArrayAccess) {
             $object[$name] = $value;
+        } else {
+            throw new \InvalidArgumentException('Please implement your own property accessor.');
         }
     }
 }

--- a/Grido/PropertyAccessors/IPropertyAccessor.php
+++ b/Grido/PropertyAccessors/IPropertyAccessor.php
@@ -21,13 +21,6 @@ interface IPropertyAccessor
     /**
      * @param mixed $object
      * @param string $name
-     * @return bool
-     */
-    public static function hasProperty($object, $name);
-
-    /**
-     * @param mixed $object
-     * @param string $name
      * @return mixed
      */
     public static function getProperty($object, $name);


### PR DESCRIPTION
Odstranění methody `hasProperty`, která nelze rozumně implementovat pro typy object a `ArrayAccess`
