### PR TITLE
Third click lost sort param from url

### DIFF
--- a/Grido/Grid.latte
+++ b/Grido/Grid.latte
@@ -56,7 +56,7 @@
                     {if $column->isSortable()}
                         <a n:if="!$column->getSort()" n:href="sort! [$column->getName() => Grido\Components\Columns\Column::ASC]" class="ajax">{_$column->label}</a>
                         <a n:if="$column->getSort() == Grido\Components\Columns\Column::ASC" n:href="sort! [$column->getName() => Grido\Components\Columns\Column::DESC]" class="sort ajax">{_$column->label}</a>
-                        <a n:if="$column->getSort() == Grido\Components\Columns\Column::DESC" n:href="sort! [$column->getName() => isset($control->defaultSort[$column->getName()]) ? '' : NULL]" class="sort ajax">{_$column->label}</a>
+                        <a n:if="$column->getSort() == Grido\Components\Columns\Column::DESC" n:href="sort! [$column->getName() => Grido\Components\Columns\Column::ASC]" class="sort ajax">{_$column->label}</a>
                         <span></span>
                     {else}
                         {_$column->label}


### PR DESCRIPTION
Při třetím kliknutí na seřazení sloupce se ztratí parametr z url. Jediný kde jsem našel nesrovnalost bylo v šabloně.

Zkoušel jsem nastavovat defaultní řazení nad jiný sloupce a teď už to podle mně funguje.

V LIVE demu když zkusíš třikrát kliknout nad jedním sloupcem pro řazení tak to uvidíš.
