### PR TITLE
setDefaultSort automatically call setSortable

### DIFF
--- a/Grido/Components/Columns/Column.php
+++ b/Grido/Components/Columns/Column.php
@@ -118,6 +118,7 @@ abstract class Column extends \Grido\Components\Base
     public function setDefaultSort($dir)
     {
         $this->grid->setDefaultSort(array($this->name => $dir));
+        $this->setSortable();
         return $this;
     }
 


### PR DESCRIPTION
Myslím si že se to hodí nechám zvážení na tobě.

namísto 
$column->setSortable()->setDefaultSort('asc');

bude stačit
$column->setDefaultSort('asc');
