### PR TITLE
Vytváření ikon až v šabloně, nové možnosti nastavení.

### DIFF
--- a/Grido/Grid.latte
+++ b/Grido/Grid.latte
@@ -15,6 +15,15 @@
 {?$form['buttons']['search']->controlPrototype->class[] = 'btn search'}
 {?$form['buttons']['reset']->controlPrototype->class[] = 'btn reset'}
 
+{if $control->hasActions()}
+	{foreach $control[\Grido\Components\Actions\Action::ID]->getComponents() as $action}
+		{if ($__icon = $action->getOption('icon')) !== NULL}
+			{?$action->elementPrototype->add(Nette\Utils\Html::el('span')->class('icon icon-' . $__icon) . ' ')}
+		{/if}
+		{?$action->elementPrototype->class[] = 'btn btn-mini'}
+	{/foreach}
+{/if}
+
 <ul n:foreach="$form->errors as $error">
     <li>{$error}</li>
 </ul>


### PR DESCRIPTION
Tato úprava je jen nástřel možného řešení. Ikony by podle mě neměly záviset na třídě Action. Inspiroval jsem se z `Nette\Forms\Controls`, kde se přesně k tomuto účelu používají metody `setOption()`.

Díky této úpravě lze migrovat na BS3 pouze změnou šablony, navíc lze definovat vlastní `options` například pro "obalení" několika tlačítek do jedné `btn-group`,... (přichystal bych v dalším commitu, pokud s tímto budeš souhlasit)

Metodu `setIcon` jsem označil jako `@deprecated`, místo toho použít `setOption('icon', ...)`
