### PR TITLE
Suggest handler vrací seřazená data + JsonResponse

### DIFF
--- a/Grido/Components/Filters/Text.php
+++ b/Grido/Components/Filters/Text.php
@@ -100,12 +100,6 @@ class Text extends Filter
             $this->getPresenter()->terminate();
         }
 
-        if (!$this->suggestion) {
-            trigger_error("Suggestion for filter '$name' is not enabled.", E_USER_NOTICE);
-            $this->getPresenter()->terminate();
-            return; //for tests
-        }
-
         $actualFilter = $this->grid->getActualFilter();
         if (isset($actualFilter[$name])) {
             unset($actualFilter[$name]);
@@ -137,6 +131,10 @@ class Text extends Filter
                 $caseInsenstive[] = $item;
             }
         }		
+        sort($startsWith);
+        sort($caseSensitive);
+        sort($caseInsenstive);
+		
         $items = array_merge($startsWith, $caseSensitive, $caseInsenstive);
 		
         $this->getPresenter()->sendResponse(new \Nette\Application\Responses\JsonResponse($items));

--- a/Grido/DataSources/ArraySource.php
+++ b/Grido/DataSources/ArraySource.php
@@ -204,9 +204,6 @@ class ArraySource extends \Nette\Object implements IDataSource
             $items[$value] = $value;
         }
 
-        $items = array_values($items);
-        sort($items);
-
-        return $items;;
+        return array_values($items);
     }
 }

--- a/Grido/DataSources/DibiFluent.php
+++ b/Grido/DataSources/DibiFluent.php
@@ -160,9 +160,6 @@ class DibiFluent extends \Nette\Object implements IDataSource
             $items[$value] = $value;
         }
 
-        $items = array_values($items);
-        sort($items);
-
-        return $items;
+        return array_values($items);
     }
 }

--- a/Grido/DataSources/Doctrine.php
+++ b/Grido/DataSources/Doctrine.php
@@ -260,9 +260,6 @@ class Doctrine extends \Nette\Object implements IDataSource
             }
         }
 
-        $items = array_values($items);
-        sort($items);
-
-        return $items;
+        return array_values($items);
     }
 }

--- a/Grido/DataSources/NetteDatabase.php
+++ b/Grido/DataSources/NetteDatabase.php
@@ -135,9 +135,6 @@ class NetteDatabase extends \Nette\Object implements IDataSource
             $items[$value] = $value;
         }
 
-        $items = array_values($items);
-        sort($items);
-
-        return $items;
+        return array_values($items);
     }
 }

--- a/tests/Grido/DataSources/TestCase.php
+++ b/tests/Grido/DataSources/TestCase.php
@@ -53,11 +53,7 @@ abstract class DataSourceTestCase extends \Tester\TestCase
         ob_start();
             Helper::request($params);
         $output = ob_get_clean();
-        Assert::same('["Awet","Caitlin","Dragotina","Katherine","Satu","Trommler"]', $output);
-
-        Assert::error(function() {
-            Helper::request(array('grid-filters-phone-query' => 'yyy', 'do' => 'grid-filters-phone-suggest'));
-        }, E_USER_NOTICE, "Suggestion for filter 'phone' is not enabled.");
+        Assert::same('["Trommler","Awet","Caitlin","Dragotina","Katherine","Satu"]', $output);
     }
 
     function testSetWhere()

--- a/tests/Grido/Helper.inc.php
+++ b/tests/Grido/Helper.inc.php
@@ -123,6 +123,15 @@ class TestPresenter extends \Nette\Application\UI\Presenter
     {
         //parent::sendTemplate(); @intentionally
     }
+	
+    public function sendResponse(\Nette\Application\IResponse $response)
+    {
+        if($response instanceof \Nette\Application\Responses\JsonResponse){
+            $response->send($this->getHttpRequest(), $this->getHttpResponse());
+        } else {
+            parent::sendResponse($response);
+        }
+    }
 
     public function isAjax()
     {


### PR DESCRIPTION
Připravil jsem řazení ze suggest handleru pro typeahead.js (je to samozřejmě funkční i s bootstrap-typeahedem - tam se v podstatě nemění nic).

To řazení jsem v podstatě okopíroval z bootstrap-typeaheadu. Prvně jsou ty co začínají tím vyhledávaným dotazem, pak jsou ty co mají to vyhledávané slovo v sobě (přičemž výše jsou case sensitive).

Taky jsem si dovolil nahradit ten print jsonu s nasledným terminate() za poslání sendresponse, které má Nette.
