### PR TITLE
ArrayObjectAccessor typo

### DIFF
--- a/Grido/PropertyAccessors/ArrayObjectAccessor.php
+++ b/Grido/PropertyAccessors/ArrayObjectAccessor.php
@@ -53,9 +53,9 @@ class ArrayObjectAccessor implements IPropertyAccessor
     public static function setProperty($object, $name, $value)
     {
         if (is_array($object)) {
-            $object->$name = $value;
-        } elseif (is_object($object)) {
             $object[$name] = $value;
+        } elseif (is_object($object)) {
+            $object->$name = $value;
         } else {
             throw new \InvalidArgumentException('Please implement your own property accessor.');
         }


### PR DESCRIPTION
Handling of arrays and object in setProperty() was reversed.
