### PR TITLE
Předávání poměnných šabloně, která vykresluje sloupec

### DIFF
--- a/Grido/Components/Columns/Column.php
+++ b/Grido/Components/Columns/Column.php
@@ -26,6 +26,7 @@ use Grido\Components\Filters\Filter;
  * @property-write callback $cellCallback
  * @property-write string $defaultSorting
  * @property-write mixed $customRender
+ * @property-write array $customRenderArgs
  * @property-write mixed $customRenderExport
  * @property-write array $replacements
  * @property-write bool $sortable
@@ -57,6 +58,9 @@ abstract class Column extends \Grido\Components\Component
 
     /** @var mixed custom rendering */
     protected $customRender;
+    
+    /** @var array custom rendering */
+    protected $customRenderArgs = array();
 
     /** @var mixed custom export rendering */
     protected $customRenderExport;
@@ -121,12 +125,20 @@ abstract class Column extends \Grido\Components\Component
     }
 
     /**
+     * 
      * @param mixed $callback callback or string for name of template filename
+     * @param array|NULL $args
      * @return Column
      */
-    public function setCustomRender($callback)
+    public function setCustomRender($callback, $args = null)
     {
         $this->customRender = $callback;
+        if(!is_null($args)) {
+                if(!is_string($callback)) {
+                    throw new \InvalidArgumentException("If second parameter was given, type must be string , $callback (".gettype($callback).") was given");
+                }
+            $this->customRenderArgs = $args;
+        }
         return $this;
     }
 
@@ -229,6 +241,15 @@ abstract class Column extends \Grido\Components\Component
     public function getCustomRender()
     {
         return $this->customRender;
+    }
+    
+    /**
+     * @return array
+     * @internal
+     */
+    public function getCustomRenderArgs()
+    {
+        return $this->customRenderArgs;
     }
 
     /**********************************************************************************************/

--- a/Grido/Grid.latte
+++ b/Grido/Grid.latte
@@ -173,7 +173,9 @@
                 {foreach $columns as $column}
                     {?$td = $column->getCellPrototype($row)}
                     {$td->startTag()|noescape}
-                        {if is_string($column->getCustomRender())}
+                        {if is_string($column->getCustomRender()) && !is_null($column->getCustomRenderArgs())}
+                            {include $column->getCustomRender() control => $control, presenter => $control->getPresenter(), item => $row, (expand)$column->getCustomRenderArgs()}
+			{elseif is_string($column->getCustomRender())}
                             {include $column->getCustomRender() control => $control, presenter => $control->getPresenter(), item => $row}
                         {else}
                             {$column->render($row)|noescape}


### PR DESCRIPTION
Chyběla mi podpora pro předávání poměnných šabloně, která vykresluje sloupec. 

``` php
->setCustomRender("$templatePath/grid.country.latte") // vytvoří šablonu jako dosud
->setCustomRender("$templatePath/grid.country.latte", ['lang' => $this->lang, 'repository' => $this->repository]) // Vytvoří šablonu a předá proměnné
```

Použití v šabloně je potom snadné.

``` php
{dump $lang}, {dump $repository}
```
