### PR TITLE
Doctrine - improvement of Doctrine Paginator

### DIFF
--- a/Grido/DataSources/Doctrine.php
+++ b/Grido/DataSources/Doctrine.php
@@ -38,6 +38,12 @@ class Doctrine extends \Nette\Object implements IDataSource
 
     /** @var array Map column to the query builder */
     protected $sortMapping;
+	
+    /** @var boolean use OutputWalker in Doctrine Paginator */
+    protected $useOutputWalkers = NULL;
+	
+    /** @var boolean fetch join collection in Doctrine Paginator */
+    protected $fetchJoinCollection = TRUE;
 
     protected $rand;
 
@@ -59,6 +65,18 @@ class Doctrine extends \Nette\Object implements IDataSource
         }
     }
 
+    public function setUseOutputWalkers($useOutputWalkers)
+    {
+        $this->useOutputWalkers = $useOutputWalkers;
+        return $this;
+    }
+
+    public function setFetchJoinCollection($fetchJoinCollection)
+    {
+        $this->fetchJoinCollection = $fetchJoinCollection;
+        return $this;
+    }
+	
     /**
      * @return \Doctrine\ORM\Query
      */
@@ -150,7 +168,8 @@ class Doctrine extends \Nette\Object implements IDataSource
      */
     public function getCount()
     {
-        $paginator = new Paginator($this->getQuery());
+        $paginator = new Paginator($this->getQuery(), $this->fetchJoinCollection);
+        $paginator->setUseOutputWalkers($this->useOutputWalkers);
         return $paginator->count();
     }
 


### PR DESCRIPTION
Allow useOutputWalkers and fetchJoinCollection for Doctrine Paginator. It is important for a lot of records in database tables. 

For example I have table with 10 000 records and it takes almost 1s/query without these features. If I use these features it is "only" 0,1 sec
