### PR TITLE
#fix - filter storing to session

### DIFF
--- a/Grido/Grid.php
+++ b/Grido/Grid.php
@@ -667,6 +667,20 @@ class Grid extends Components\Container
             : array();
 
         foreach ($values as $name => $value) {
+            // do not save a prompt value of selectbox
+            if ($value === NULL
+                && (
+                    isset($sessionFilter[$name])
+                    || (
+                        isset($this->defaultFilter[$name])
+                        && $this->defaultFilter[$name] === NULL
+                    )
+                )
+            ) {
+               unset($this->filter[$name]);
+               continue;
+            }
+
             $value = (string) $value; //maybe this could be removed
             if ($value != '' || isset($this->defaultFilter[$name]) || isset($sessionFilter[$name])) {
                 $this->filter[$name] = $this->getFilter($name)->changeValue($value);


### PR DESCRIPTION
If I used custom filter and set remember state to TRUE, stored value could be out of range selectbox filter. I admit, I did not try remove this line "$value = (string) $value;" from code for lack the time of testing stability.