### PR TITLE
Fixed filtering in Doctrine over joined columns

### DIFF
--- a/Grido/DataSources/Doctrine.php
+++ b/Grido/DataSources/Doctrine.php
@@ -12,7 +12,8 @@
 namespace Grido\DataSources;
 
 use Doctrine\ORM\Tools\Pagination\Paginator,
-    Grido\Components\Filters\Condition;
+    Grido\Components\Filters\Condition,
+    Nette\Utils\Strings;
 
 /**
  * Doctrine data source.
@@ -137,7 +138,7 @@ class Doctrine extends \Nette\Object implements IDataSource
             if (!Condition::isOperator($column)) {
                 $columns[$key] = isset($this->filterMapping[$column])
                     ? $this->filterMapping[$column]
-                    : $this->qb->getRootAlias() . '.' . $column;
+                    : Strings::contains($column, ".") ? $column : $this->qb->getRootAlias() . '.' . $column;
             }
         }
 


### PR DESCRIPTION
So, I stumbled upon a weird bug today.

When you build your doctrine data source from QueryBuilder containing a join, like this:

`$ordersDao->createQueryBuilder('o')->join('o.customer', 'c')->where('o.isActive = true');`

And then build a grid and in some column set text filter via `Grido\Components\Filters\Text::setColumn()`, refercing `c.fullName`, the built query is syntactically wrong, because it contains `o.c.fullName` instead of `c.fullName`.

This should fix the issue. If you don't feel like this is a proper fix, tell me how to do it and I'll redo the pull request.
