### PR TITLE
Grid::saveRememberState() save AJAX filter in Nette >= 5.2

### DIFF
--- a/Grido/Grid.php
+++ b/Grido/Grid.php
@@ -774,7 +774,9 @@ class Grid extends Components\Container
     {
         if ($this->rememberState) {
             $session = $this->getRememberSession(TRUE);
-            $session->params = $this->params;
+            foreach(array_keys($this->getReflection()->getPersistentParams()) as $param) {
+				$session->params[$param] = $this->$param;
+			}
         }
     }
 


### PR DESCRIPTION
V aktualni verzi Nette 2.3-dev nefungovalo spravne zapamatovani filtrovani se zaplym AJAXem. Filtr se aplikoval, nicmene se hodnoty filtry neulozili do session. Pouze pokud se stisklo tlaciko "filtruj" primo v gridu.
