### PR TITLE
attach `ui` & `event` arguments to ajax requests

### DIFF
--- a/client-side/grido.js
+++ b/client-side/grido.js
@@ -100,13 +100,13 @@
                         };
 
                     if (hasConfirm && confirm(hasConfirm)) {
-                        isAjax && (that.ajax.doRequest(this.href) || stop(event));
+                        isAjax && (that.ajax.doRequest(this.href, this, event) || stop(event));
 
                     } else if (hasConfirm) {
                         stop(event);
 
                     } else if (isAjax) {
-                        that.ajax.doRequest(this.href) || stop(event);
+                        that.ajax.doRequest(this.href, this, event) || stop(event);
                     }
                 });
         },


### PR DESCRIPTION
related PR https://github.com/o5/grido-sandbox/pull/16

This change allows `settings.nette` to be set properly in `$.nette.ajax` thus `history.ext.js` (among others) work properly even for grido actions
