### PR TITLE
Fix js file for inline editation-regex

### DIFF
--- a/client-side/grido.js
+++ b/client-side/grido.js
@@ -544,7 +544,7 @@
         getComponentName: function($th)
         {
             var handler = this.getEditControlHandlerUrl($th).replace('/[\.d]*/g', '');
-            handler = handler.match(/[\??\&?][do=]+(.*)/)[1];
+            handler = handler.match(/[\??\&?](do=)+(.*)/)[2];
 
             return handler.match(/(.*)\-edit/)[1];
         },


### PR DESCRIPTION
Inline editation ajax requests called "bjectType" instead of "objectType"
Problem was with regex parsing get variables.
original code takes "do=o" instead of exact "do="

Week spent,
So i fixed that nonsense :)
