### PR TITLE
Columns/Editable: fix for setting editableRowCallback

### DIFF
--- a/src/Components/Columns/Editable.php
+++ b/src/Components/Columns/Editable.php
@@ -108,7 +108,7 @@ abstract class Editable extends Column
     public function setEditableRowCallback($callback)
     {
         $this->isEditable() ?: $this->setEditable();
-        $this->editableValueCallback = $callback;
+        $this->editableRowCallback = $callback;
 
         return $this;
     }


### PR DESCRIPTION
change of variable which was set by method setEditableRowCallback (formerly $editableValueCallback instead of $editableRowCallback)
