### PR TITLE
Escape the slash delimiter in ArraySource 

### DIFF
--- a/src/DataSources/ArraySource.php
+++ b/src/DataSources/ArraySource.php
@@ -93,7 +93,7 @@ class ArraySource extends \Nette\Object implements IDataSource
         $cond = str_replace(' ?', '', $condition);
 
         if ($cond === 'LIKE') {
-            $pattern = str_replace('%', '(.|\s)*', preg_quote($expected));
+            $pattern = str_replace('%', '(.|\s)*', preg_quote($expected, '/'));
             return (bool) preg_match("/^{$pattern}$/i", $actual);
 
         } elseif ($cond === '=') {


### PR DESCRIPTION
Changing the `compare()` function:
The slash delimiter should be also escaped within the `preg_quote` function to allow the user to use a string containing the slash in  the `LIKE` condition.
