### PR TITLE
Large CSV export memory problem solved

### DIFF
--- a/src/Components/Export.php
+++ b/src/Components/Export.php
@@ -125,6 +125,6 @@ class Export extends Component implements \Nette\Application\IResponse
         $httpResponse->setHeader('Content-Type', "text/csv; charset=$charset");
         $httpResponse->setHeader('Content-Disposition', "attachment; filename=\"$file\"; filename*=utf-8''$file");
 
-        print $source;
+        echo $source;
     }
 }

--- a/src/Components/Export.php
+++ b/src/Components/Export.php
@@ -102,7 +102,7 @@ class Export extends Component implements \Nette\Application\IResponse
     {
         $file = $this->label . '.csv';
 
-        $model = $this->grid->getModel();
+        $model = $this->grid->getDataForCsv();
         $numberOfIterations = ceil($model->getCount() / self::FETCH_LIMIT);
         $columns = $this->grid[\Grido\Components\Columns\Column::ID]->getComponents();
         $source = $this->generateCsvHeader($columns);

--- a/src/Components/Export.php
+++ b/src/Components/Export.php
@@ -121,7 +121,7 @@ class Export extends Component implements \Nette\Application\IResponse
         $source = "\xFF\xFE" . $source; //add BOM
 
         $httpResponse->setHeader('Content-Encoding', $charset);
-        $httpResponse->setHeader('Content-Length', mb_strlen($source));
+        $httpResponse->setHeader('Content-Length', strlen($source));
         $httpResponse->setHeader('Content-Type', "text/csv; charset=$charset");
         $httpResponse->setHeader('Content-Disposition', "attachment; filename=\"$file\"; filename*=utf-8''$file");
 

--- a/src/Components/Export.php
+++ b/src/Components/Export.php
@@ -18,7 +18,8 @@ namespace Grido\Components;
  * @subpackage  Components
  * @author      Petr Bugyík
  */
-class Export extends Component implements \Nette\Application\IResponse {
+class Export extends Component implements \Nette\Application\IResponse
+{
 
     const ID = 'export';
     const FETCH_LIMIT = 1000;
@@ -27,7 +28,8 @@ class Export extends Component implements \Nette\Application\IResponse {
      * @param \Grido\Grid $grid
      * @param string $label
      */
-    public function __construct(\Grido\Grid $grid, $label = NULL) {
+    public function __construct(\Grido\Grid $grid, $label = NULL)
+    {
         $this->grid = $grid;
         $this->label = $label === NULL ? ucfirst($this->grid->getName()) : $label;
 
@@ -38,7 +40,8 @@ class Export extends Component implements \Nette\Application\IResponse {
      * @param \Nette\ComponentModel\RecursiveComponentIterator $columns
      * @return string
      */
-    protected function generateCsvHeader(\Nette\ComponentModel\RecursiveComponentIterator $columns) {
+    protected function generateCsvHeader(\Nette\ComponentModel\RecursiveComponentIterator $columns)
+    {
         $head = array();
         foreach ($columns as $column) {
             $head[] = $column->getLabel();
@@ -58,7 +61,8 @@ class Export extends Component implements \Nette\Application\IResponse {
      * @param \Nette\ComponentModel\RecursiveComponentIterator $columns
      * @return string
      */
-    protected function generateCsv($data, \Nette\ComponentModel\RecursiveComponentIterator $columns) {
+    protected function generateCsv($data, \Nette\ComponentModel\RecursiveComponentIterator $columns)
+    {
         $resource = fopen('php://temp/maxmemory:' . (5 * 1024 * 1024), 'r+'); // 5MB of memory allocated
 
         foreach ($data as $item) {
@@ -80,7 +84,8 @@ class Export extends Component implements \Nette\Application\IResponse {
     /**
      * @internal
      */
-    public function handleExport() {
+    public function handleExport()
+    {
         $this->grid->onRegistered && $this->grid->onRegistered($this->grid);
         $this->grid->presenter->sendResponse($this);
     }
@@ -93,7 +98,8 @@ class Export extends Component implements \Nette\Application\IResponse {
      * @param \Nette\Http\IResponse $httpResponse
      * @return void
      */
-    public function send(\Nette\Http\IRequest $httpRequest, \Nette\Http\IResponse $httpResponse) {
+    public function send(\Nette\Http\IRequest $httpRequest, \Nette\Http\IResponse $httpResponse)
+    {
         $file = $this->label . '.csv';
 
         $model = $this->grid->getModel();
@@ -106,7 +112,7 @@ class Export extends Component implements \Nette\Application\IResponse {
             $model->limit($currentOffset, self::FETCH_LIMIT);
             $data = $model->getData();
             $csvData = $this->generateCsv($data, $columns);
-            $source.=$csvData;
+            $source .= $csvData;
             unset($data);
         }
 
@@ -121,5 +127,4 @@ class Export extends Component implements \Nette\Application\IResponse {
 
         print $source;
     }
-
 }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -469,6 +469,18 @@ class Grid extends Components\Container
     }
 
     /**
+     * Returns data for CSV export
+     * @return DataSources\IDataSource
+     */
+    public function getDataForCsv()
+    {
+        $data = $this->getModel();
+        $this->applyFiltering();
+        $this->applySorting();
+        return $data;
+    }
+
+    /**
      * Returns translator.
      * @return Translations\FileTranslator
      */


### PR DESCRIPTION
Solution to export data from grid to CSV in case of large data amount. The problem is to get all data from database to memory, so I have divided this part to several small parts which can get into memory. For those who export small data amount there is no difference - their data will be usually exported in one cycle.