### PR TITLE
if action setCustomRender() callback return NULL use default rendering

### DIFF
--- a/src/Components/Actions/Action.php
+++ b/src/Components/Actions/Action.php
@@ -241,8 +241,11 @@ abstract class Action extends \Grido\Components\Component
         $element = $this->getElement($row);
 
         if ($this->customRender) {
-            echo callback($this->customRender)->invokeArgs(array($row, $element));
-            return;
+            $callback = callback($this->customRender)->invokeArgs(array($row, $element));
+            if ( $callback !== NULL ){
+                echo $callback;
+                return;
+            }
         }
 
         echo $element->render();


### PR DESCRIPTION
If we need leave default rendering. for action buttons.

This example is for hiding or show disabled button or any else render if my $item->url is empty else leave default
```php
        $grid->addActionEvent('control_a', 'URL Redirect', function($a) use ($self){ 
            $item = $self->cats->find($id);
            $self->redirectUrl( $item->url );
        })
            ->setCustomRender(function($item){
                return $item->url != '' && $item->url !== NULL ? NULL : '';
            });
```