### PR TITLE
travis: few improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: php
 
 php:
+  - 5.3
+  - 5.4
   - 5.5
   - 5.6
+  - 7.0
+
+matrix:
+  allow_failures:
+    - php: 5.3
+    - php: 5.4
+    - php: 7.0
 
 before_script:
-  # Update Composer
-  - composer self-update
-
   # Install Nette Tester
-  - composer install --no-interaction --prefer-source --dev
+  - composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/tester tests -s


### PR DESCRIPTION
- PHP 7.0 added; PHP 5.3, 5.4 returned (as it's requirement in composer.json) - all with allowed failure
- no need to update composer (Travis keeps 1 month convention and more fresh features might be untested by other packages)
- `--dev` is by default