### PR TITLE
Grid: Fixed session name

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -485,7 +485,7 @@ class Grid extends Components\Container
         }
 
         return $session->isStarted()
-            ? $session->getSection($presenter->getName() . '\\' . ucfirst($this->getName()))
+            ? ($session->getSection($this->getUniqueId()))
             : NULL;
     }
 

--- a/tests/Grid/GridAsSubcomponent.phpt
+++ b/tests/Grid/GridAsSubcomponent.phpt
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test: Grid.
+ *
+ * @author     Svaťa Šimara
+ * @package    Grido\Tests
+ */
+
+namespace Grido\Tests;
+
+use Tester\Assert,
+    Grido\Grid,
+    Grido\Components\Columns\Column,
+    Grido\Components\Filters\Filter;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+eval('class Subcomponent extends \Nette\Application\UI\Control {}');
+
+class GridInSubcomponentTest extends \Tester\TestCase
+{
+
+    function testSessionsInDifferentGridsWithTheSameNameAreIndenpendent() {
+        
+        Helper::grid(function(){})->run();
+        $presenter = Helper::$presenter;
+        
+        $presenter->onStartUp[] = function(TestPresenter $presenter){
+
+            $subcomponent1 = new \Subcomponent($presenter, 'subcomponent1');
+            $grid1 = new Grid($subcomponent1, 'grid');
+            $grid1->setRememberState();
+            $session1 = $grid1->getRememberSession();
+            $session1->name = 'a';
+            Assert::same($session1->name, 'a');
+            
+            $subcomponent2 = new \Subcomponent($presenter, 'subcomponent2');
+            $grid2 = new Grid($subcomponent2, 'grid');
+            $grid2->setRememberState();
+            $session2 = $grid2->getRememberSession();
+            $session2->name = 'b';
+            
+            Assert::same($session1->name, 'a');
+            Assert::same($session2->name, 'b');
+        };
+        
+        $request = new \Nette\Application\Request('Test', \Nette\Http\Request::GET, array());
+        $presenter->run($request);
+    }
+}
+
+run(__FILE__);


### PR DESCRIPTION
Test case je docela komplikovaný, potřeboval sem dva gridy najednou.
Pardon za eval(), nevěděl jsem, jak vytvořit třídu, aniž by byla automaticky testovaná.

Jde o situaci, kdy máte na jednom presenteru tuto strukturu komponent:
├ subcomponent1
│├ grid
├ subcomponent2
│├ grid

Oba gridy mají remember state. Po vyfiltrování na jednom gridu jsou filtry aplikovány ze session i na druhý grid. Což je docela blbé, protože mají obvykle různé sloupečky a pokus o zafiltrování končí docela rychle chybou.