### PR TITLE
Fixes wrong CSV export, dont use UTF-16LE

### DIFF
--- a/src/Components/Export.php
+++ b/src/Components/Export.php
@@ -100,12 +100,11 @@ class Export extends Component implements \Nette\Application\IResponse
      */
     public function send(\Nette\Http\IRequest $httpRequest, \Nette\Http\IResponse $httpResponse)
     {
-        $encoding = 'UTF-16LE';
+        $encoding = 'UTF-8';
         $file = $this->label . '.csv';
 
-        $source = $this->generateSource();
-        $source = mb_convert_encoding($source, $encoding, 'UTF-8');
-        $source = "\xFF\xFE" . $source; //add BOM
+        $source = chr(0xEF) . chr(0xBB) . chr(0xBF); //UTF-8 BOM
+        $source .= $this->generateSource();
 
         $httpResponse->setHeader('Content-Encoding', $encoding);
         $httpResponse->setHeader('Content-Length', mb_strlen($source, $encoding));


### PR DESCRIPTION
Hi there!

Using UTF-16LE is UGLY half working HACK to make M$O Excel (Under OS X ?) happy...
This is not right way to go^ (buggy cos mb_strlen returns wrong len and exported file is pure mess)

Solutions:

* Keep standard UTF-8 with small UTF-8 BOM hack for excel
* Split Export into two versions as button with multiple options (Excel / All other non garbage sw)
* Give us option to decide (as parameter for setExport($label = NULL, $excel = FALSE) )

As you can see in diff i picked first option, and i'm not alone: 
http://stackoverflow.com/questions/4348802/how-can-i-output-a-utf-8-csv-in-php-that-excel-will-read-properly/4762708#4762708  (Accepted UTF-16LE: 44 votes vs 139 votes for UTF-8)

