### PR TITLE
Grid: setRememberState don't require to be attached to presenter

### DIFF
--- a/tests/Grid/GridAsSubcomponent.phpt
+++ b/tests/Grid/GridAsSubcomponent.phpt
@@ -31,14 +31,14 @@ class GridInSubcomponentTest extends \Tester\TestCase
             $subcomponent1 = new \Subcomponent($presenter, 'subcomponent1');
             $grid1 = new Grid($subcomponent1, 'grid');
             $grid1->setRememberState();
-            $session1 = $grid1->getRememberSession();
+            $session1 = $grid1->getRememberSession(TRUE);
             $session1->name = 'a';
             Assert::same($session1->name, 'a');
             
             $subcomponent2 = new \Subcomponent($presenter, 'subcomponent2');
             $grid2 = new Grid($subcomponent2, 'grid');
             $grid2->setRememberState();
-            $session2 = $grid2->getRememberSession();
+            $session2 = $grid2->getRememberSession(TRUE);
             $session2->name = 'b';
             
             Assert::same($session1->name, 'a');


### PR DESCRIPTION
Pokiaľ vytváram grid pomocou továrničky, tak nebolo možné volať `setRememberState()` pretože to vyžadovalo presenter.
Upravil som aj prácu zo session pretože pokiaľ nebola naštartovaná session tak to vyhadzovalo výnimku.
Upravil som to tak, že keď sa nepodarí naštartovať session tak nevyhodí chybu `Headers already sent` ale pracuje tak, akoby bola session prázdna.

Pokiaľ sa volá nejaký signál tak sa session naštartovať podarí, pretože signály sa spracujú ešte pred renderingom,

