### PR TITLE
Added wildcard options for remote

### DIFF
--- a/client-side/js/plugins/grido.typeahead.js
+++ b/client-side/js/plugins/grido.typeahead.js
@@ -33,7 +33,8 @@
                 datumTokenizer: window.Bloodhound.tokenizers.obj.whitespace('value'),
                 queryTokenizer: window.Bloodhound.tokenizers.whitespace,
                 remote: {
-                    url: url.replace(wildcard, '%QUERY')
+                    url: url.replace(wildcard, '%QUERY'),
+                    wildcard: '%QUERY'
                 }
             };
 


### PR DESCRIPTION
Doesn't worked without it.
typeahead + bloodhound 0.11.1