### PR TITLE
Translator fix: does not translate page numbers anymore

### DIFF
--- a/src/Grid.php
+++ b/src/Grid.php
@@ -926,7 +926,8 @@ class Grid extends Components\Container
             ->onClick[] = callback($this, 'handlePerPage');
 
         $form->addSelect('count', 'Count', $this->getItemsForCountSelect())
-            ->controlPrototype->attrs['title'] = $this->getTranslator()->translate('Grido.ItemsPerPage');
+            ->controlPrototype->attrs['title'] = $this->getTranslator()->translate('Grido.ItemsPerPage')
+            ->setTranslator(NULL);
     }
 
     /**


### PR DESCRIPTION
When using a translator, it tried to translate the numbers in "items per page" select box.