### PR TITLE
selected row highlighting bugfix

### DIFF
--- a/client-side/js/grido.js
+++ b/client-side/js/grido.js
@@ -194,6 +194,7 @@
             }
 
             this.initSelectState();
+            this.initActiveRows();
             this.bindClickOnCheckbox();
             this.bindClickOnRow();
             this.bindClickOnInvertor();
@@ -209,6 +210,10 @@
             $(this.selector + ':checked', this.grido.$table).length === 0 && this.controlState('disabled');
         },
 
+        initActiveRows: function()
+        {
+            $(this.selector + ':checked', this.grido.$table).closest('tr').addClass('active');
+        },
         /**
          * Click on checkbox with shift support.
          */


### PR DESCRIPTION
this should fix initial selected rows highlighting

steps to reproduce:
* open http://grido.bugyik.cz/example/inner/multi-render/ (ajax state enabled)
* select some rows in "Grido three" example
* click action button search (empty filter is OK)
* the grid is refreshed and the rows selected in step two stays selected
* the selected rows are not highlighted (missing "active" class)

note: shouldn't the rows selection be cleared when user resets the filter by reset button?