### PR TITLE
Update grido.js

### DIFF
--- a/client-side/js/grido.js
+++ b/client-side/js/grido.js
@@ -635,7 +635,7 @@
          */
         getPrimaryKeyValue: function($tr)
         {
-            return $tr.attr('class').match(/[grid\-row\-]([0-9]+)/)[1];
+            return $tr.attr('class').match(/[grid\-row\-](.+)/)[1];
         },
 
         /**


### PR DESCRIPTION
Je nějaký důvod proč tam musí být [0-9] ?

Ne každý číselník musí být numerický, například číselník států, měn kde primární klíč je kod země/kod měny.