### PR TITLE
Update grido.js

### DIFF
--- a/assets/js/grido.js
+++ b/assets/js/grido.js
@@ -239,7 +239,7 @@
         bindClickOnRow: function()
         {
             var that = this;
-            $('tbody td:not(.checker,.actions a)', this.grido.$table)
+            $('tbody td:not(.checker,.actions)', this.grido.$table)
                 .off('click.grido')
                 .on('click.grido', function(event) {
                     if ($(this).hasClass('edit')) {


### PR DESCRIPTION
Nevím jak to udělat lépe, ale podmínka td:not(.actions a) určitě nefunguje, chybu jsem vyřešil odstraněním odkazu ze selectoru což způsobí že nelze klikat v celé oblasti akcí. 

Je otázkou jestli je to potřeba.