### PR TITLE
Fixing th sort class adding

### DIFF
--- a/src/Components/Columns/Column.php
+++ b/src/Components/Columns/Column.php
@@ -194,9 +194,8 @@ abstract class Column extends \Grido\Components\Component
         }
 
         if ($this->isSortable() && $this->getSort()) {
-            $this->headerPrototype->class[] = $this->getSort() == self::ORDER_DESC
-                ? 'desc'
-                : 'asc';
+            $sortClass = $this->getSort() == self::ORDER_DESC ? 'desc' : 'asc';
+        	$this->headerPrototype->addAttributes(['class' => $sortClass]);
         }
 
         return $this->headerPrototype;


### PR DESCRIPTION
In case when you use ->getHeaderPrototype()->addAttributes(['class' => 'someclass']), function getHeaderPrototype() triggers fatal error '[] operator not supported for strings'. This fix solves problem.