### PR TITLE
MemberAccessException on Nette 2.4

### DIFF
--- a/src/templates/bootstrap.latte
+++ b/src/templates/bootstrap.latte
@@ -34,7 +34,7 @@
 
     {foreach $actions as $action}
         {php
-            $element = $action->elementPrototype;
+            $element = $action->getElementPrototype();
             $element->class[] = $customization->buttonClass;
 
             if ($icon = $action->getOption('icon')) {
@@ -46,7 +46,7 @@
 
     {foreach $buttons as $button}
         {php
-            $element = $button->elementPrototype;
+            $element = $button->getElementPrototype();
             $element->class[] = $customization->buttonClass;
 
             if ($icon = $button->getOption('icon')) {


### PR DESCRIPTION
 Fix access for elementPrototype property in Action and Button classess.

On Nette 2.4: "Cannot read a write-only property Grido\Components\Button::$elementPrototype"

Thanks!