### PR TITLE
Remove of Nette\Object and replace with trait Nette\SmartObject

### DIFF
--- a/assets/js/grido.js
+++ b/assets/js/grido.js
@@ -68,11 +68,14 @@
          */
         initFilters: function()
         {
+            var that = this;
             $('.filter select, .filter [type=checkbox]', this.$element)
                 .off('change.grido')
-                .on('change.grido', this.sendFilterForm);
+                .on('change.grido', function(){
+                    that.sendFilterForm();
+                });
 
-            var that = this;
+
             $('.filter input, .filter textarea', this.$element)
                 .off('focus.grido')
                 .on('focus.grido', function() {

--- a/src/Components/Filters/Condition.php
+++ b/src/Components/Filters/Condition.php
@@ -12,6 +12,7 @@
 namespace Grido\Components\Filters;
 
 use Grido\Exception;
+use Nette;
 
 /**
  * Builds filter condition.
@@ -25,8 +26,11 @@ use Grido\Exception;
  * @property mixed $value
  * @property-read callable $callback
  */
-class Condition extends \Nette\Object
+class Condition
 {
+
+    use Nette\SmartObject;
+
     const OPERATOR_OR = 'OR';
     const OPERATOR_AND = 'AND';
 

--- a/src/Customization.php
+++ b/src/Customization.php
@@ -11,8 +11,7 @@
 
 namespace Grido;
 
-use Grido\Grid;
-use Nette\Object;
+use Nette;
 
 /**
  * Customization.
@@ -23,8 +22,10 @@ use Nette\Object;
  * @property string|array $buttonClass
  * @property string|array $iconClass
  */
-class Customization extends Object
+class Customization
 {
+
+    use Nette\SmartObject;
 
     const TEMPLATE_DEFAULT = 'default';
     const TEMPLATE_BOOTSTRAP = 'bootstrap';

--- a/src/DataSources/ArraySource.php
+++ b/src/DataSources/ArraySource.php
@@ -13,8 +13,8 @@ namespace Grido\DataSources;
 
 use Grido\Exception;
 use Grido\Components\Filters\Condition;
-
 use Nette\Utils\Strings;
+use Nette;
 
 /**
  * Array data source.
@@ -27,8 +27,10 @@ use Nette\Utils\Strings;
  * @property-read array $data
  * @property-read int $count
  */
-class ArraySource extends \Nette\Object implements IDataSource
+class ArraySource implements IDataSource
 {
+    use Nette\SmartObject;
+
     /** @var array */
     protected $data;
 

--- a/src/DataSources/DibiFluent.php
+++ b/src/DataSources/DibiFluent.php
@@ -12,6 +12,7 @@
 namespace Grido\DataSources;
 
 use Grido\Exception;
+use Nette;
 
 /**
  * Dibi Fluent data source.
@@ -26,8 +27,10 @@ use Grido\Exception;
  * @property-read int $count
  * @property-read array $data
  */
-class DibiFluent extends \Nette\Object implements IDataSource
+class DibiFluent  implements IDataSource
 {
+    use Nette\SmartObject;
+
     /** @var \DibiFluent */
     protected $fluent;
 

--- a/src/DataSources/Doctrine.php
+++ b/src/DataSources/Doctrine.php
@@ -17,6 +17,7 @@ use Grido\Components\Filters\Condition;
 use Nette\Utils\Strings;
 use Nette\Utils\Random;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use Nette;
 
 /**
  * Doctrine data source.
@@ -32,8 +33,10 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
  * @property-read int $count
  * @property-read array $data
  */
-class Doctrine extends \Nette\Object implements IDataSource
+class Doctrine implements IDataSource
 {
+    use Nette\SmartObject;
+
     /** @var \Doctrine\ORM\QueryBuilder */
     protected $qb;
 

--- a/src/DataSources/Model.php
+++ b/src/DataSources/Model.php
@@ -12,6 +12,7 @@
 namespace Grido\DataSources;
 
 use Grido\Exception;
+use Nette;
 
 /**
  * Model of data source.
@@ -22,8 +23,10 @@ use Grido\Exception;
  *
  * @property-read IDataSource $dataSource
  */
-class Model extends \Nette\Object
+class Model
 {
+    use Nette\SmartObject;
+
     /** @var array */
     public $callback = [];
 

--- a/src/DataSources/NetteDatabase.php
+++ b/src/DataSources/NetteDatabase.php
@@ -13,6 +13,7 @@ namespace Grido\DataSources;
 
 use Grido\Exception;
 use Grido\Components\Filters\Condition;
+use Nette;
 
 /**
  * Nette Database data source.
@@ -25,8 +26,10 @@ use Grido\Components\Filters\Condition;
  * @property-read int $count
  * @property-read array $data
  */
-class NetteDatabase extends \Nette\Object implements IDataSource
+class NetteDatabase implements IDataSource
 {
+    use Nette\SmartObject;
+
     /** @var \Nette\Database\Table\Selection */
     protected $selection;
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -136,6 +136,22 @@ class Grid extends Components\Container
     protected $customization;
 
     /**
+     * Grid constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        list($parent, $name) = func_get_args() + [null, null];
+        if ($parent !== null) {
+            $parent->addComponent($this, $name);
+
+        } elseif (is_string($name)) {
+            $this->name = $name;
+        }
+    }
+
+
+    /**
      * Sets a model that implements the interface Grido\DataSources\IDataSource or data-source object.
      * @param mixed $model
      * @param bool $forceWrapper

--- a/src/Translations/FileTranslator.php
+++ b/src/Translations/FileTranslator.php
@@ -12,6 +12,7 @@
 namespace Grido\Translations;
 
 use Grido\Exception;
+use Nette;
 
 /**
  * Simple file translator.
@@ -20,8 +21,10 @@ use Grido\Exception;
  * @subpackage  Translations
  * @author      Petr Bugyík
  */
-class FileTranslator extends \Nette\Object implements \Nette\Localization\ITranslator
+class FileTranslator implements \Nette\Localization\ITranslator
 {
+    use Nette\SmartObject;
+
     /** @var array */
     protected $translations = [];
 


### PR DESCRIPTION
Since Nette\Utils 2.5.X throws use of Nette\Object an exception (on development environment). It is suggested to replace Nette\Object with trait Nette\SmartObject. 
This change should increase compatibility with php 7.2. and Grido.