### PR TITLE
Remove of Nette\Object and replace with trait Nette\SmartObject v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
         - php: hhvm
 
 before_install:
-    - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then COVERAGE="-c `php -i | grep 'xdebug.ini'` --coverage coverage.xml --coverage-src src/"; else COVERAGE="" && if [ $TRAVIS_PHP_VERSION = '5.6' ]; then phpenv config-rm xdebug.ini; fi; fi
+    - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then COVERAGE="-c `php -i | grep 'xdebug.ini'` --coverage coverage.xml --coverage-src=src/ "; else COVERAGE="" && if [ $TRAVIS_PHP_VERSION = '5.6' ]; then phpenv config-rm xdebug.ini; fi; fi
     - composer global require hirak/prestissimo
 
 install:

--- a/assets/js/grido.js
+++ b/assets/js/grido.js
@@ -68,9 +68,12 @@
          */
         initFilters: function()
         {
+            var that = this;
             $('.filter select, .filter [type=checkbox]', this.$element)
                 .off('change.grido')
-                .on('change.grido', this.sendFilterForm);
+                .on('change.grido', function(){
+                    that.sendFilterForm();
+                });
 
             var that = this;
             $('.filter input, .filter textarea', this.$element)

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "nette/tester": "~1.7.1",
         "mockery/mockery": "~0.9.3",
         "dibi/dibi": "~3.0.1",
-        "kdyby/doctrine": "~3.1.2",
+        "kdyby/doctrine": "~3.3.0",
         "squizlabs/php_codesniffer": "~2.5"
     }
 }

--- a/src/Components/Filters/Condition.php
+++ b/src/Components/Filters/Condition.php
@@ -25,8 +25,10 @@ use Grido\Exception;
  * @property mixed $value
  * @property-read callable $callback
  */
-class Condition extends \Nette\Object
+class Condition
 {
+    use \Nette\SmartObject;
+
     const OPERATOR_OR = 'OR';
     const OPERATOR_AND = 'AND';
 

--- a/src/Customization.php
+++ b/src/Customization.php
@@ -12,7 +12,6 @@
 namespace Grido;
 
 use Grido\Grid;
-use Nette\Object;
 
 /**
  * Customization.
@@ -23,8 +22,9 @@ use Nette\Object;
  * @property string|array $buttonClass
  * @property string|array $iconClass
  */
-class Customization extends Object
+class Customization
 {
+    use \Nette\SmartObject;
 
     const TEMPLATE_DEFAULT = 'default';
     const TEMPLATE_BOOTSTRAP = 'bootstrap';

--- a/src/DataSources/ArraySource.php
+++ b/src/DataSources/ArraySource.php
@@ -27,8 +27,10 @@ use Nette\Utils\Strings;
  * @property-read array $data
  * @property-read int $count
  */
-class ArraySource extends \Nette\Object implements IDataSource
+class ArraySource implements IDataSource
 {
+    use \Nette\SmartObject;
+
     /** @var array */
     protected $data;
 

--- a/src/DataSources/DibiFluent.php
+++ b/src/DataSources/DibiFluent.php
@@ -26,8 +26,10 @@ use Grido\Exception;
  * @property-read int $count
  * @property-read array $data
  */
-class DibiFluent extends \Nette\Object implements IDataSource
+class DibiFluent implements IDataSource
 {
+    use \Nette\SmartObject;
+
     /** @var \DibiFluent */
     protected $fluent;
 

--- a/src/DataSources/Doctrine.php
+++ b/src/DataSources/Doctrine.php
@@ -32,8 +32,10 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
  * @property-read int $count
  * @property-read array $data
  */
-class Doctrine extends \Nette\Object implements IDataSource
+class Doctrine implements IDataSource
 {
+    use \Nette\SmartObject;
+
     /** @var \Doctrine\ORM\QueryBuilder */
     protected $qb;
 

--- a/src/DataSources/Model.php
+++ b/src/DataSources/Model.php
@@ -22,8 +22,10 @@ use Grido\Exception;
  *
  * @property-read IDataSource $dataSource
  */
-class Model extends \Nette\Object
+class Model
 {
+    use \Nette\SmartObject;
+
     /** @var array */
     public $callback = [];
 

--- a/src/DataSources/NetteDatabase.php
+++ b/src/DataSources/NetteDatabase.php
@@ -25,8 +25,10 @@ use Grido\Components\Filters\Condition;
  * @property-read int $count
  * @property-read array $data
  */
-class NetteDatabase extends \Nette\Object implements IDataSource
+class NetteDatabase implements IDataSource
 {
+    use \Nette\SmartObject;
+
     /** @var \Nette\Database\Table\Selection */
     protected $selection;
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -141,10 +141,10 @@ class Grid extends Components\Container
     public function __construct()
     {
         parent::__construct();
-        list($parent, $name) = func_get_args() + [null, null];
-        if ($parent !== null) {
+        list($parent, $name) = func_get_args() + [NULL, NULL];
+        if ($parent !== NULL) {
             $parent->addComponent($this, $name);
-         } elseif (is_string($name)) {
+        } elseif (is_string($name)) {
             $this->name = $name;
         }
     }

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -136,6 +136,20 @@ class Grid extends Components\Container
     protected $customization;
 
     /**
+     * Grid constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        list($parent, $name) = func_get_args() + [null, null];
+        if ($parent !== null) {
+            $parent->addComponent($this, $name);
+         } elseif (is_string($name)) {
+            $this->name = $name;
+        }
+    }
+
+    /**
      * Sets a model that implements the interface Grido\DataSources\IDataSource or data-source object.
      * @param mixed $model
      * @param bool $forceWrapper

--- a/src/Translations/FileTranslator.php
+++ b/src/Translations/FileTranslator.php
@@ -20,8 +20,10 @@ use Grido\Exception;
  * @subpackage  Translations
  * @author      Petr Bugyík
  */
-class FileTranslator extends \Nette\Object implements \Nette\Localization\ITranslator
+class FileTranslator implements \Nette\Localization\ITranslator
 {
+    use \Nette\SmartObject;
+
     /** @var array */
     protected $translations = [];
 

--- a/tests/Components/Export.phpt
+++ b/tests/Components/Export.phpt
@@ -17,8 +17,10 @@ use Tester\Assert,
 
 require_once __DIR__ . '/../bootstrap.php';
 
-class Response extends \Nette\Object implements \Nette\Http\IResponse
+class Response implements \Nette\Http\IResponse
 {
+    use \Nette\SmartObject;
+
     public static $headers = [];
 
     function setHeader($name, $value)

--- a/tests/Components/Operation.phpt
+++ b/tests/Components/Operation.phpt
@@ -61,7 +61,7 @@ class OperationTest extends \Tester\TestCase
             $grid->addColumnText('b', 'B');
             $grid->setOperation(['edit' => 'Edit', 'del' => 'Del'], function($operation, $id) {
                 Assert::same('edit', $operation);
-                Assert::same(['2','4'], $id);
+                Assert::same(['2', '4'], $id);
             });
         };
         Helper::grid(function(Grid $grid) use ($definition) {

--- a/tests/DataSources/files/doctrine/entities/Country.php
+++ b/tests/DataSources/files/doctrine/entities/Country.php
@@ -2,7 +2,6 @@
 
 namespace Grido\Tests\Entities;
 
-use Nette\Object;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -14,8 +13,10 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="country")
  */
-class Country extends Object
+class Country
 {
+    use \Nette\SmartObject;
+
     /**
      * @var string
      * @ORM\Id

--- a/tests/DataSources/files/doctrine/entities/User.php
+++ b/tests/DataSources/files/doctrine/entities/User.php
@@ -2,7 +2,6 @@
 
 namespace Grido\Tests\Entities;
 
-use Nette\Object;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -14,8 +13,10 @@ use Doctrine\ORM\Mapping as ORM;
  * @ORM\Entity
  * @ORM\Table(name="user")
  */
-class User extends Object
+class User
 {
+    use \Nette\SmartObject;
+
     /**
      * @var int
      * @ORM\Id

--- a/tests/Grid/Grid.phpt
+++ b/tests/Grid/Grid.phpt
@@ -241,7 +241,7 @@ class GridTest extends \Tester\TestCase
         Assert::type('\Grido\Translations\FileTranslator', $grid->translator);
 
         Assert::exception(function() use ($grid) {
-            $grid->translator->lang = 'aa';
+            $grid->translator->setLang('aa');
         }, '\Grido\Exception');
     }
 

--- a/tests/Grid/GridAsSubcomponent.phpt
+++ b/tests/Grid/GridAsSubcomponent.phpt
@@ -26,15 +26,19 @@ class GridInSubcomponentTest extends \Tester\TestCase
 
         $presenter->onStartUp[] = function(TestPresenter $presenter){
 
-            $subcomponent1 = new Subcomponent($presenter, 'subcomponent1');
-            $grid1 = new Grid($subcomponent1, 'grid');
+            $subcomponent1 = new Subcomponent();
+            $presenter->addComponent($subcomponent1, 'subcomponent1');
+            $grid1 = new Grid();
+            $subcomponent1->addComponent($grid1, 'grid1');
             $grid1->setRememberState();
             $session1 = $grid1->getRememberSession();
             $session1->name = 'a';
             Assert::same($session1->name, 'a');
 
-            $subcomponent2 = new Subcomponent($presenter, 'subcomponent2');
-            $grid2 = new Grid($subcomponent2, 'grid');
+            $subcomponent2 = new Subcomponent();
+            $presenter->addComponent($subcomponent2, 'subcomponent2');
+            $grid2 = new Grid();
+            $subcomponent2->addComponent($grid2, 'grid2');
             $grid2->setRememberState();
             $session2 = $grid2->getRememberSession();
             $session2->name = 'b';

--- a/tests/Grid/render.multi.phpt
+++ b/tests/Grid/render.multi.phpt
@@ -31,7 +31,8 @@ class Multirender extends \Tester\TestCase
             $grid->addColumnText('surname', 'Surname');
             $grid->addColumnText('gender', 'Gender');
             $grid->addColumnText('birthday', 'Birthday');
-            $grid->templateFile = $grid->customization->templateFiles[$template];
+            $templateFiles = $grid->customization->getTemplateFiles();
+            $grid->templateFile = $templateFiles[$template];
         };
 
         $addFilters = function($grid) {

--- a/tests/config.neon
+++ b/tests/config.neon
@@ -25,5 +25,8 @@ doctrine:
 extensions:
     console: Kdyby\Console\DI\ConsoleExtension
 
+application:
+    scanDirs: false
+
 di:
     accessors: true


### PR DESCRIPTION
Since Nette\Utils 2.5.X throws use of Nette\Object an exception (on development environment). It is suggested to replace Nette\Object with trait Nette\SmartObject.
This change should increase compatibility with PHP 7.2. and Grido.