### PR TITLE
Optimize LIKE expressions in ArraySource filters.

### DIFF
--- a/tests/DataSources/ArraySource.phpt
+++ b/tests/DataSources/ArraySource.phpt
@@ -77,6 +77,11 @@ class ArraySourceTest extends DataSourceTestCase
         Assert::true($source->compare('Žluťoučký kůň', 'LIKE ?', 'zlutou%'));
         Assert::true($source->compare('Žluťoučký kůň', 'LIKE ?', 'žlutou%'));
 
+        $extraLongText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nunc diam, maximus a imperdiet et, iaculis quis metus. Donec est turpis, pharetra a lacus nec, pellentesque volutpat velit. Nunc iaculis ipsum in nisl porta, non ornare enim dapibus. Vestibulum a arcu fermentum, semper est vitae, congue odio. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed accumsan sapien at tempus feugiat. Mauris sit amet quam ultricies, hendrerit massa sit amet, posuere turpis.";
+        Assert::true($source->compare($extraLongText, 'LIKE ?', "%{$extraLongText}%"));
+        Assert::true($source->compare("some prefix " . $extraLongText, 'LIKE ?', "%{$extraLongText}"));
+        Assert::true($source->compare($extraLongText . " some sufix", 'LIKE ?', "{$extraLongText}%"));
+
         Assert::true($source->compare('Lucie', '=', 'Lucie'));
         Assert::false($source->compare('Lucie', '=', 'lucie'));
 


### PR DESCRIPTION
Hi,
I came across a bug with filtering long texts with ArraySource. 
There is catastrophic backtracking when using `preg_match`. That is why I rewrote filtering using string matching functions.

PS: Please backport this PR to older versions of Grido. Thanks.