### PR TITLE
fix php 8.1 deprecations in Column::applyReplacements

### DIFF
--- a/src/Components/Columns/Column.php
+++ b/src/Components/Columns/Column.php
@@ -336,8 +336,8 @@ abstract class Column extends \Grido\Components\Component
      */
     protected function applyReplacement($value)
     {
-        if ((is_scalar($value) || $value === NULL) && isset($this->replacements[$value])) {
-            $replaced = $this->replacements[$value];
+        if ((is_scalar($value) || $value === NULL) && isset($this->replacements[(string) $value])) {
+            $replaced = $this->replacements[(string) $value];
             if (is_scalar($replaced)) {
                 $replaced = $this->translate($replaced);
             }


### PR DESCRIPTION
Prevents

```
PHP Deprecated: Implicit conversion from float 22.5 to int loses precision in /app/vendor/o5/grido/src/Components/Columns/Column.php:339
```

in PHP >= 8.1